### PR TITLE
fix: `tslib` should be listed as dependency

### DIFF
--- a/.changeset/fuzzy-dogs-worry.md
+++ b/.changeset/fuzzy-dogs-worry.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+fix: `tslib` should be listed as dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
     "": {
       "name": "napi-postinstall",
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
       "bin": {
         "napi-postinstall": "lib/cli.js"
       },
@@ -63,7 +67,7 @@
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts"
+        "url": "https://opencollective.com/napi-postinstall"
       }
     },
     "node_modules/@1stg/babel-preset": {
@@ -23086,9 +23090,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.com/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The `postinstall` script helper for handling native bindings in legacy `npm` versions",
   "repository": "git+https://github.com/un-ts/napi-postinstall.git",
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
-  "funding": "https://opencollective.com/unts",
+  "funding": "https://opencollective.com/napi-postinstall",
   "license": "MIT",
   "packageManager": "npm@11.3.0",
   "engines": {
@@ -45,6 +45,9 @@
     "typecov": "type-coverage",
     "vercel-build": "npm i -D @esbuild/linux-x64 @rollup/rollup-linux-x64-gnu @swc/core-linux-x64-gnu && npm run docs:build",
     "version": "changeset version && npm i"
+  },
+  "dependencies": {
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@1stg/browserslist-config": "^2.1.4",


### PR DESCRIPTION
close unrs/unrs-resolver#71

close import-js/eslint-import-resolver-typescript#436