### PR TITLE
fix: always use `wasm32-wasi` target for `webcontainer`

### DIFF
--- a/.changeset/fair-pillows-divide.md
+++ b/.changeset/fair-pillows-divide.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+fix: always use `wasm32-wasi` target for `webcontainer`

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "./lib/index.js",
-    "limit": "2.5kB"
+    "limit": "2.6kB"
   }
 ]

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -255,6 +255,9 @@ export function getNapiNativeTarget(): string[] | string {
 const WASI_TARGET = 'wasm32-wasi'
 
 export function getNapiNativeTargets() {
+  if (process.versions.webcontainer) {
+    return [WASI_TARGET]
+  }
   const targets = getNapiNativeTarget()
   if (Array.isArray(targets)) {
     return [...targets, WASI_TARGET]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for WebAssembly (WASI) environments by ensuring consistent target selection and handling during installation and setup.
  - Adjusted installation process and file management for WASI targets, including proper handling of package directories and binary file extensions.

- **Chores**
  - Increased the allowed size limit for the main library file to accommodate recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->