### PR TITLE
fix: give up patching `yarn` pnp automatically which is impossible

### DIFF
--- a/.changeset/fresh-worms-suffer.md
+++ b/.changeset/fresh-worms-suffer.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+fix: give up patching `yarn` pnp automatically which is impossible

--- a/.github/workflows/pkg-size.yml
+++ b/.github/workflows/pkg-size.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Package Size Report

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -13,7 +13,8 @@ jobs:
   size-limit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node.js LTS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -12,9 +12,11 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Check Branch
         id: branch

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "./lib/index.js",
-    "limit": "2.6kB"
+    "limit": "3kB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run",
     "typecov": "type-coverage",
     "vercel-build": "yarn docs:build",
-    "version": "changeset version && yarn --no-immutable && yarn test"
+    "version": "changeset version && yarn --no-immutable && yarn test -u"
   },
   "devDependencies": {
     "@1stg/browserslist-config": "^2.1.4",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,9 +4,11 @@ import { PackageJson } from './types.js'
 
 export const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/'
 
-export const { name, version } = require(
+export const meta = require(
   path.resolve(__dirname, '../package.json'),
 ) as PackageJson
+
+const { name, version } = meta
 
 export const LOG_PREFIX = `[${name}@${version}] `
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-import { DEFAULT_NPM_REGISTRY } from './constants.js'
+import { DEFAULT_NPM_REGISTRY, LOG_PREFIX } from './constants.js'
 import { parseTriple } from './target.js'
 import { NapiInfo, PackageJson } from './types.js'
 
@@ -59,7 +59,9 @@ export function getNapiInfoFromPackageJson(
 
   if (!targets?.length) {
     throw new Error(
-      `No \`napi.targets\` nor \`napi.triples.additional\` field found in \`${name}\`'s \`package.json\`. Please ensure the package is built with NAPI support.`,
+      errorMessage(
+        `No \`napi.targets\` nor \`napi.triples.additional\` field found in \`${name}\`'s \`package.json\`. Please ensure the package is built with NAPI support.`,
+      ),
     )
   }
 
@@ -90,7 +92,9 @@ export function getNapiInfoFromPackageJson(
     if (version) {
       if (checkVersion && version !== packageVersion) {
         throw new Error(
-          `Inconsistent package versions found for \`${name}\` with \`${pkg}\` v${packageVersion} vs v${version}.`,
+          errorMessage(
+            `Inconsistent package versions found for \`${name}\` with \`${pkg}\` v${packageVersion} vs v${version}.`,
+          ),
         )
       }
     } else if (packageVersion) {
@@ -267,4 +271,12 @@ export function getNapiNativeTargets() {
 
 export function getErrorMessage(err: unknown) {
   return (err as Error | undefined)?.message || String(err)
+}
+
+export function errorLog(message: string, ...args: unknown[]) {
+  console.error(`${LOG_PREFIX}${message}`, ...args)
+}
+
+export function errorMessage(message: string, extra?: string) {
+  return `${LOG_PREFIX}${message}` + (extra ? ': ' + extra : '')
 }

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -18,7 +18,7 @@ describe('napi-postinstall', () => {
     await expect(
       checkAndPreparePackage('napi-postinstall'),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: No \`napi.targets\` nor \`napi.triples.additional\` field found in \`napi-postinstall\`'s \`package.json\`. Please ensure the package is built with NAPI support.]`,
+      `[Error: [napi-postinstall@0.2.1] No \`napi.targets\` nor \`napi.triples.additional\` field found in \`napi-postinstall\`'s \`package.json\`. Please ensure the package is built with NAPI support.]`,
     )
   })
 })

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -6,37 +6,48 @@ vi.setConfig({ testTimeout: 5 * 60_000 })
 
 const fixtures = path.resolve(__dirname, 'fixtures')
 
+const removeUnrelatedWarnings = (stderr: string) =>
+  stderr
+    .split(/\r?\n/)
+    .filter(
+      line =>
+        !line.startsWith('npm warn') &&
+        !line.startsWith('! Corepack is about to download'),
+    )
+    .join('\n')
+    .trim()
+
 describe('npm fixture', () => {
-  it('should just work', () =>
-    expect(
-      exec('npm', ['install'], {
-        nodeOptions: {
-          cwd: path.resolve(fixtures, 'npm'),
-        },
-      }),
-    ).resolves.not.toThrow())
+  it('should just work', async () => {
+    const res = await exec('npm', ['install'], {
+      nodeOptions: {
+        cwd: path.resolve(fixtures, 'npm'),
+      },
+    })
+    expect(removeUnrelatedWarnings(res.stderr)).toBe('')
+  })
 })
 
 describe('npm-10 fixture', () => {
-  it('should just work', () =>
-    expect(
-      exec('npm', ['install'], {
-        nodeOptions: {
-          cwd: path.resolve(fixtures, 'npm-10'),
-        },
-      }),
-    ).resolves.not.toThrow())
+  it('should just work', async () => {
+    const res = await exec('npm', ['install'], {
+      nodeOptions: {
+        cwd: path.resolve(fixtures, 'npm-10'),
+      },
+    })
+    expect(removeUnrelatedWarnings(res.stderr)).toBe('')
+  })
 })
 
 describe('pnpm fixture', () => {
-  it('should just work', () =>
-    expect(
-      exec('pnpm', ['install'], {
-        nodeOptions: {
-          cwd: path.resolve(fixtures, 'pnpm'),
-        },
-      }),
-    ).resolves.not.toThrow())
+  it('should just work', async () => {
+    const res = await exec('pnpm', ['install'], {
+      nodeOptions: {
+        cwd: path.resolve(fixtures, 'pnpm'),
+      },
+    })
+    expect(removeUnrelatedWarnings(res.stderr)).toBe('')
+  })
 })
 
 describe('yarn fixture', () => {
@@ -46,17 +57,17 @@ describe('yarn fixture', () => {
         cwd: path.resolve(fixtures, 'yarn'),
       },
     })
-    expect(res.stderr).toEqual('')
+    expect(removeUnrelatedWarnings(res.stderr)).toBe('')
   })
 })
 
 describe('yarn pnp fixture', () => {
-  it('should just work', async () => {
+  it('should not work and warn user', async () => {
     const res = await exec('yarn', [], {
       nodeOptions: {
         cwd: path.resolve(fixtures, 'yarn-pnp'),
       },
     })
-    expect(res.stderr).toEqual('')
+    expect(removeUnrelatedWarnings(res.stderr)).toBe('')
   })
 })

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -40,23 +40,23 @@ describe('pnpm fixture', () => {
 })
 
 describe('yarn fixture', () => {
-  it('should just work', () =>
-    expect(
-      exec('yarn', [], {
-        nodeOptions: {
-          cwd: path.resolve(fixtures, 'yarn'),
-        },
-      }),
-    ).resolves.not.toThrow())
+  it('should just work', async () => {
+    const res = await exec('yarn', [], {
+      nodeOptions: {
+        cwd: path.resolve(fixtures, 'yarn'),
+      },
+    })
+    expect(res.stderr).toEqual('')
+  })
 })
 
 describe('yarn pnp fixture', () => {
-  it('should just work', () =>
-    expect(
-      exec('yarn', [], {
-        nodeOptions: {
-          cwd: path.resolve(fixtures, 'yarn-pnp'),
-        },
-      }),
-    ).resolves.not.toThrow())
+  it('should just work', async () => {
+    const res = await exec('yarn', [], {
+      nodeOptions: {
+        cwd: path.resolve(fixtures, 'yarn-pnp'),
+      },
+    })
+    expect(res.stderr).toEqual('')
+  })
 })

--- a/test/fixtures/yarn-pnp/.gitignore
+++ b/test/fixtures/yarn-pnp/.gitignore
@@ -1,4 +1,5 @@
 .yarn/*
+!.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 .pnp.*

--- a/test/fixtures/yarn-pnp/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch
+++ b/test/fixtures/yarn-pnp/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index a6d83fe865fc01552188ef678dec1eaf4a33aff3..69d87cdcbe0a8c489213c321b1543947fc40211f 100644
+--- a/package.json
++++ b/package.json
+@@ -263,6 +263,7 @@
+       "require": "./dist/parseAst.js",
+       "import": "./dist/es/parseAst.js"
+     },
+-    "./dist/*": "./dist/*"
++    "./dist/*": "./dist/*",
++    "./package.json": "./package.json"
+   }
+ }

--- a/test/fixtures/yarn-pnp/.yarnrc.yml
+++ b/test/fixtures/yarn-pnp/.yarnrc.yml
@@ -1,3 +1,5 @@
+nodeLinker: pnp
+
 enableTelemetry: false
 
 plugins:

--- a/test/fixtures/yarn-pnp/package.json
+++ b/test/fixtures/yarn-pnp/package.json
@@ -6,7 +6,7 @@
     "prepare": "node ./postinstall.js"
   },
   "devDependencies": {
-    "napi-postinstall": "link:../../..",
+    "napi-postinstall": "portal:../../..",
     "rollup": "^4.40.0"
   }
 }

--- a/test/fixtures/yarn-pnp/package.json
+++ b/test/fixtures/yarn-pnp/package.json
@@ -7,6 +7,6 @@
   },
   "devDependencies": {
     "napi-postinstall": "portal:../../..",
-    "rollup": "^4.40.0"
+    "rollup": "patch:rollup@npm%3A4.40.0#~/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch"
   }
 }

--- a/test/fixtures/yarn-pnp/yarn.lock
+++ b/test/fixtures/yarn-pnp/yarn.lock
@@ -680,7 +680,7 @@ __metadata:
   resolution: "napi-postinstall-yarn-pnp@workspace:."
   dependencies:
     napi-postinstall: "portal:../../.."
-    rollup: "npm:^4.40.0"
+    rollup: "patch:rollup@npm%3A4.40.0#~/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch"
   languageName: unknown
   linkType: soft
 
@@ -792,7 +792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.40.0":
+"rollup@npm:4.40.0":
   version: 4.40.0
   resolution: "rollup@npm:4.40.0"
   dependencies:
@@ -864,6 +864,81 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/90aa57487d4a9a7de1a47bf42a6091f83f1cb7fe1814650dfec278ab8ddae5736b86535d4c766493517720f334dfd4aa0635405ca8f4f36ed8d3c0f875f2a801
+  languageName: node
+  linkType: hard
+
+"rollup@patch:rollup@npm%3A4.40.0#~/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch":
+  version: 4.40.0
+  resolution: "rollup@patch:rollup@npm%3A4.40.0#~/.yarn/patches/rollup-npm-4.40.0-5ee51badc3.patch::version=4.40.0&hash=af8cfc"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.40.0"
+    "@rollup/rollup-android-arm64": "npm:4.40.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.40.0"
+    "@rollup/rollup-darwin-x64": "npm:4.40.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.40.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.40.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.40.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.40.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.40.0"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.40.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.40.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.40.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.40.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.40.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.40.0"
+    "@types/estree": "npm:1.0.7"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loongarch64-gnu":
+      optional: true
+    "@rollup/rollup-linux-powerpc64le-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/5dd843cbdf6fad452fc0100fa66281c70b67cdc6f8710447762a35e6acdb150dbc339af3347ae3124cca9f58716ce81831e924cba86084bab8c61298111b3807
   languageName: node
   linkType: hard
 

--- a/test/fixtures/yarn-pnp/yarn.lock
+++ b/test/fixtures/yarn-pnp/yarn.lock
@@ -679,14 +679,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "napi-postinstall-yarn-pnp@workspace:."
   dependencies:
-    napi-postinstall: "link:../../.."
+    napi-postinstall: "portal:../../.."
     rollup: "npm:^4.40.0"
   languageName: unknown
   linkType: soft
 
-"napi-postinstall@link:../../..::locator=napi-postinstall-yarn-pnp%40workspace%3A.":
+"napi-postinstall@portal:../../..::locator=napi-postinstall-yarn-pnp%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "napi-postinstall@link:../../..::locator=napi-postinstall-yarn-pnp%40workspace%3A."
+  resolution: "napi-postinstall@portal:../../..::locator=napi-postinstall-yarn-pnp%40workspace%3A."
+  bin:
+    napi-postinstall: ./lib/cli.js
   languageName: node
   linkType: soft
 

--- a/test/fixtures/yarn/.yarnrc.yml
+++ b/test/fixtures/yarn/.yarnrc.yml
@@ -1,3 +1,5 @@
+nodeLinker: node-modules
+
 enableTelemetry: false
 
 plugins:

--- a/test/fixtures/yarn/package.json
+++ b/test/fixtures/yarn/package.json
@@ -6,7 +6,7 @@
     "prepare": "node ./postinstall.js"
   },
   "devDependencies": {
-    "napi-postinstall": "link:../../..",
+    "napi-postinstall": "portal:../../..",
     "rollup": "^4.40.0"
   }
 }

--- a/test/fixtures/yarn/yarn.lock
+++ b/test/fixtures/yarn/yarn.lock
@@ -679,14 +679,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "napi-postinstall-yarn@workspace:."
   dependencies:
-    napi-postinstall: "link:../../.."
+    napi-postinstall: "portal:../../.."
     rollup: "npm:^4.40.0"
   languageName: unknown
   linkType: soft
 
-"napi-postinstall@link:../../..::locator=napi-postinstall-yarn%40workspace%3A.":
+"napi-postinstall@portal:../../..::locator=napi-postinstall-yarn%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "napi-postinstall@link:../../..::locator=napi-postinstall-yarn%40workspace%3A."
+  resolution: "napi-postinstall@portal:../../..::locator=napi-postinstall-yarn%40workspace%3A."
+  bin:
+    napi-postinstall: ./lib/cli.js
   languageName: node
   linkType: soft
 


### PR DESCRIPTION
Yarn PnP doesn't work with this, but tests claim it does. There are three reasons

1. nodeLinker was not specified explicitly, so pnp _may_ not have been used
2. The `link` protocol doesn't capture the dependency behaviour correctly
3. The tests are not catching failures! - running `yarn` in the fixtures directory shows the error, but the tests claim everything is fine.

edit: ah the problem is that yarn is not exiting non-zero with this error, just emitting errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Yarn configurations to specify node linker strategies and track patch directories.
  - Changed local dependency references from "link:" to "portal:" protocol in development dependencies.
  - Improved test cases to explicitly check for error-free execution and updated error message expectations.
  - Enhanced error logging consistency and robustness in package installation and path resolution.
  - Updated versioning script to refresh test snapshots during release.
  - Refined package metadata handling and error message formatting for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->