### PR TITLE
fix: `newPath` dir could be unavailable, make sure it's already there

### DIFF
--- a/.changeset/eight-balloons-relax.md
+++ b/.changeset/eight-balloons-relax.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+fix: `newPath` dir could be unavailable, make sure it's already there

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,7 +37,7 @@ export function removeRecursive(dir: string) {
 
 export function downloadedNodePath(name: string, subpath: string) {
   const pkgLibDir = path.dirname(require.resolve(name + '/package.json'))
-  return path.join(pkgLibDir, `${path.basename(subpath)}`)
+  return path.join(pkgLibDir, path.basename(subpath))
 }
 
 export function getNapiInfoFromPackageJson(


### PR DESCRIPTION
close unrs/unrs-resolver#108

Without reproduction, I can only guess the root cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the target directory for certain files might not exist by ensuring it is created before use, preventing related errors.

- **Refactor**
  - Simplified path handling by introducing a reusable variable for the node modules directory.
  - Streamlined code for path construction and improved directory management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->