### PR TITLE
fix: target `ES2020` for Node <15 compatibility

### DIFF
--- a/.changeset/wet-bottles-boil.md
+++ b/.changeset/wet-bottles-boil.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+fix: target `ES2020` for Node <15 compatibility

--- a/README.md
+++ b/README.md
@@ -128,5 +128,5 @@ Detailed changes for each release are documented in [CHANGELOG.md](./CHANGELOG.m
 [swc-core]: https://github.com/swc-project/swc
 [unrs-resolver]: https://github.com/unrs/unrs-resolver
 [1stG.me]: https://www.1stG.me
-[JounQin]: https://GitHub.com/JounQin
+[JounQin]: https://github.com/JounQin
 [MIT]: http://opensource.org/licenses/MIT

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "paths": {
       "napi-postinstall": ["./src/index.ts"]
     },
-    "target": "ES2021"
+    "target": "ES2020"
   }
 }


### PR DESCRIPTION
close #31
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix capitalization in URL for `[JounQin]` link in `README.md`.
> 
>   - **Documentation**:
>     - Fix capitalization in URL for `[JounQin]` link in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fnapi-postinstall&utm_source=github&utm_medium=referral)<sup> for 6dece473071f373ab9f8079d34f7c7a198e4994e. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved compatibility issues with Node.js versions earlier than 15 by updating the ECMAScript target to ES2020.

- **Documentation**
  - Corrected the casing in a URL within the README for consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->