### PR TITLE
feat: handle 307 and 308 redirect status codes

### DIFF
--- a/.changeset/calm-avocados-invite.md
+++ b/.changeset/calm-avocados-invite.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+feat: handle 307 and 308 redirect status codes

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,11 @@ function fetch(url: string) {
   return new Promise<Buffer>((resolve, reject) => {
     https
       .get(url, res => {
-        if (REDIRECT_STATUS_CODES.has(res.statusCode) && res.headers.location) {
+        if (
+          res.statusCode &&
+          REDIRECT_STATUS_CODES.has(res.statusCode) &&
+          res.headers.location
+        ) {
           fetch(res.headers.location).then(resolve, reject)
           return
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,10 @@ function fetch(url: string) {
     https
       .get(url, res => {
         if (
-          (res.statusCode === 301 || res.statusCode === 302) &&
+          (res.statusCode === 301 ||
+            res.statusCode === 302 ||
+            res.statusCode === 307 ||
+            res.statusCode === 308) &&
           res.headers.location
         ) {
           fetch(res.headers.location).then(resolve, reject)

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,7 @@ function fetch(url: string) {
     https
       .get(url, res => {
         if (
-          res.statusCode &&
-          REDIRECT_STATUS_CODES.has(res.statusCode) &&
+          REDIRECT_STATUS_CODES.has(res.statusCode!) &&
           res.headers.location
         ) {
           fetch(res.headers.location).then(resolve, reject)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,17 +21,13 @@ import type { PackageJson } from './types.js'
 
 export type * from './types.js'
 
+const REDIRECT_STATUS_CODES = new Set([301, 302, 307, 308])
+
 function fetch(url: string) {
   return new Promise<Buffer>((resolve, reject) => {
     https
       .get(url, res => {
-        if (
-          (res.statusCode === 301 ||
-            res.statusCode === 302 ||
-            res.statusCode === 307 ||
-            res.statusCode === 308) &&
-          res.headers.location
-        ) {
+        if (REDIRECT_STATUS_CODES.has(res.statusCode) && res.headers.location) {
           fetch(res.headers.location).then(resolve, reject)
           return
         }


### PR DESCRIPTION
## Summary
  - Add support for HTTP 307 (Temporary Redirect) and 308 (Permanent Redirect) status codes in the redirect handling logic

  ## Changes
  - Add support for HTTP 307 (Temporary Redirect) and 308 (Permanent Redirect) status codes to handle redirects from our private registry.
  - Ensures proper handling of all standard HTTP redirect status codes
  
  We've already handled 301 and 302, so it will be fine!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for HTTP 307 and 308 redirect status codes in `fetch()` in `src/index.ts`.
> 
>   - **Behavior**:
>     - Update `fetch()` in `src/index.ts` to handle HTTP 307 and 308 status codes in addition to 301 and 302.
>     - Ensures proper handling of all standard HTTP redirect status codes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fnapi-postinstall&utm_source=github&utm_medium=referral)<sup> for 6092ba50f1a318248296a2ab4b3ea0abda794789. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP redirects to support additional status codes, ensuring smoother navigation and resource loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->