### PR TITLE
Support for HTTP Protocol in Private Registries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { execSync } from 'node:child_process'
 import * as fs from 'node:fs'
+import * as http from 'node:http'
 import * as https from 'node:https'
 import * as path from 'node:path'
 import * as zlib from 'node:zlib'
@@ -25,7 +26,9 @@ const REDIRECT_STATUS_CODES = new Set([301, 302, 307, 308])
 
 function fetch(url: string) {
   return new Promise<Buffer>((resolve, reject) => {
-    https
+    const apiClient = url.startsWith('https://') ? https : http
+
+    apiClient
       .get(url, res => {
         if (
           REDIRECT_STATUS_CODES.has(res.statusCode!) &&


### PR DESCRIPTION
fixes: #46

### Description

Fixes ERR_INVALID_PROTOCOL error when using HTTP-based private npm registries.

We still support HTTPS and it's prioritized.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for HTTP protocol in private npm registries by modifying `fetch()` in `index.ts` to handle both HTTP and HTTPS.
> 
>   - **Behavior**:
>     - Fixes `ERR_INVALID_PROTOCOL` error for HTTP-based private npm registries by supporting HTTP in `fetch()` in `index.ts`.
>     - Prioritizes HTTPS over HTTP when both are available.
>   - **Code Changes**:
>     - Modifies `fetch()` in `index.ts` to use `http` or `https` based on URL scheme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fnapi-postinstall&utm_source=github&utm_medium=referral)<sup> for 6047e3263b2259b7ccf8cc86d0282e743afbdf9e. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request handling to support both HTTP and HTTPS URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->