### PR TITLE
feat: try reading package.json from cwd

### DIFF
--- a/.changeset/early-buttons-appear.md
+++ b/.changeset/early-buttons-appear.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+feat: try reading `package.json` from `cwd` for cli usage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,36 @@
 #!/usr/bin/env node
 
-import { checkAndPreparePackage } from './index.js'
+import * as fs from 'node:fs'
 
-void checkAndPreparePackage(
-  process.argv[2],
-  process.argv[3],
-  ['1', 'check', 'true', 'yes'].includes(process.argv[4]),
-)
+import { PACKAGE_JSON } from './constants'
+
+import { checkAndPreparePackage, PackageJson } from './index.js'
+
+function readCwdPackage(
+  packageName: string,
+  packageVersion: string,
+): PackageJson | undefined {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(PACKAGE_JSON, 'utf8'),
+    ) as PackageJson
+    if (
+      packageJson.name === packageName &&
+      packageJson.version === packageVersion
+    ) {
+      return packageJson
+    }
+  } catch {}
+}
+
+const packageName = process.argv[2]
+const packageVersion = process.argv[3]
+const checkVersion = ['1', 'check', 'true', 'yes'].includes(process.argv[4])
+
+const packageJson = readCwdPackage(packageName, packageVersion)
+
+if (packageJson) {
+  void checkAndPreparePackage(packageJson, checkVersion)
+} else {
+  void checkAndPreparePackage(packageName, packageVersion, checkVersion)
+}


### PR DESCRIPTION
- fixes https://github.com/un-ts/napi-postinstall/issues/49
- fixes https://github.com/unrs/unrs-resolver/issues/184
- closes #50

Alternative approach that only runs on the cli variant
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `readCwdPackage` in `src/cli.ts` to read `package.json` from the current directory, addressing specific issues.
> 
>   - **Behavior**:
>     - Adds `readCwdPackage` function in `src/cli.ts` to read `package.json` from the current working directory.
>     - If `package.json` name matches `process.argv[2]`, uses it in `checkAndPreparePackage`.
>     - Falls back to original behavior if no match.
>   - **Issues Fixed**:
>     - Fixes https://github.com/un-ts/napi-postinstall/issues/49.
>     - Fixes https://github.com/unrs/unrs-resolver/issues/184.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fnapi-postinstall&utm_source=github&utm_medium=referral)<sup> for c76b4293a147b0a56dcaf834cc2dd2240ed773f4. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now attempts to use information from the local package manifest when available, enabling more seamless integration with local projects.

* **Bug Fixes**
  * Improved handling of package information by preferring local data when it matches the specified package, reducing potential mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->