### PR TITLE
feat: add support for loong64 arch and openharmony platform

### DIFF
--- a/.changeset/cuddly-doors-add.md
+++ b/.changeset/cuddly-doors-add.md
@@ -1,0 +1,5 @@
+---
+"napi-postinstall": patch
+---
+
+feat: add support for loong64 arch and openharmony platform

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,14 @@
 export interface Napi {
   binaryName?: string
-  /** @deprecated USe @link {binaryName} instead */
+  /** @deprecated Use @link {binaryName} instead */
   name?: string
   packageName?: string
-  /** @deprecated USe @link {packageName} instead */
+  /** @deprecated Use @link {packageName} instead */
   package?: {
     name: string
   }
   targets?: string[]
-  /** @deprecated USe @link {targets} instead */
+  /** @deprecated Use @link {targets} instead */
   triples?: {
     defaults?: boolean
     additional?: string[]
@@ -32,7 +32,7 @@ export interface PackageJson {
   napi?: Napi
 }
 
-export type Platform = NodeJS.Platform | 'wasi' | 'wasm'
+export type Platform = NodeJS.Platform | 'openharmony' | 'wasi' | 'wasm'
 
 export type NodeJSArch = NodeJS.Architecture | 'universal' | 'wasm32' | 'x32'
 


### PR DESCRIPTION
close #42
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `loong64` architecture and `openharmony` platform in `helpers.ts`, `target.ts`, and `types.ts`.
> 
>   - **Behavior**:
>     - Add support for `loong64` architecture in `getNapiNativeTarget()` in `helpers.ts`.
>     - Add support for `openharmony` platform in `getNapiNativeTarget()` in `helpers.ts`.
>   - **Platform Parsing**:
>     - Update `parseTriple()` in `target.ts` to handle `loongarch64` and `ohos` as `loong64` and `openharmony` respectively.
>   - **Types**:
>     - Add `openharmony` to `Platform` type in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fnapi-postinstall&utm_source=github&utm_medium=referral)<sup> for 7f9959fd762f2ebcaf195edb2b30469d78009616. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenHarmony platform support across target detection and mapping.
  * Added LoongArch (loong64) architecture support with musl/gnu selection on Linux.
  * Improved Windows x64 target resolution to include MinGW when detected.
  * Enhanced triple parsing to treat Android and OpenHarmony as subsystems for accurate platform/ABI mapping.

* **Chores**
  * Added changeset entry for the patch/feature release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->